### PR TITLE
Transfer SNPchip ID-to-TOB ID Excel file to main

### DIFF
--- a/reports/concordance/transfer_excel_map.sh
+++ b/reports/concordance/transfer_excel_map.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 
-# Transfer SNPchip ID-to-TOB ID Excel file into temporary bucket
-# gcloud -q auth activate-service-account --key-file=/gsa-key/key.json"
-
+# Transfer SNPchip ID-to-TOB ID Excel file into main bucket
 INPUT_EXCEL="gs://cpg-tob-wgs-snpchipdata/data/OneK1K_sample_IDs_2021-Apr-15.xlsx"
 
-if [[ "${OUTPUT}" =~ "gs://cpg-tob-wgs-temporary/peterd-snpchip" ]]; then
+if [[ "${OUTPUT}" =~ "gs://cpg-tob-wgs-main/snpchip/v1" ]]; then
     gsutil cp "${INPUT_EXCEL}" "${OUTPUT}"
 fi

--- a/reports/concordance/transfer_excel_map.sh
+++ b/reports/concordance/transfer_excel_map.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Transfer SNPchip ID-to-TOB ID Excel file into temporary bucket
+# gcloud -q auth activate-service-account --key-file=/gsa-key/key.json"
+
+INPUT_EXCEL="gs://cpg-tob-wgs-snpchipdata/data/OneK1K_sample_IDs_2021-Apr-15.xlsx"
+
+if [[ "${OUTPUT}" =~ "gs://cpg-tob-wgs-temporary/peterd-snpchip" ]]; then
+    gsutil cp "${INPUT_EXCEL}" "${OUTPUT}"
+fi


### PR DESCRIPTION
Perhaps we're not supposed to do this yet (not sure where we are with setting up proper metadata), but I need the ID map in the same bucket as the SNPchip VCF. Or should I put a copy of the SNPchip VCF into `temporary` too?

— Happy to convert that Excel file to a TSV if that makes things better.