### PR TITLE
run concordance on v2-raw.mt

### DIFF
--- a/reports/concordance/batch_concordance.py
+++ b/reports/concordance/batch_concordance.py
@@ -38,9 +38,9 @@ if __name__ == '__main__':
 
     BUCKET = 'gs://cpg-tob-wgs-main'
     SNP = f'{BUCKET}/snpchip/v1/snpchip_grch38.mt'
-    WGS = f'{BUCKET}/mt/v1-raw.mt'
+    WGS = f'{BUCKET}/mt/v2-raw.mt'
     CPU = 16
-    PREFIX = 'v1-raw_chr22'
+    PREFIX = 'v2-raw_chr22'
     HTML = f'{PREFIX}.html'
     concordance = concordance(b, SNP, WGS, CPU)
     b.write_output(concordance.html, f'{BUCKET}-web/concordance/v1/{HTML}')


### PR DESCRIPTION
Took 14 minutes on 190 samples for v1-raw.mt (just chr22) - report at https://main-web.populationgenomics.org.au/tob-wgs/concordance/v1/v1-raw_chr22.html. Now will include those extra 94 (I think) samples in `v2-raw.mt`.