### PR TITLE
Generate genotype df

### DIFF
--- a/scripts/generate_genotype_df/README.md
+++ b/scripts/generate_genotype_df/README.md
@@ -1,6 +1,6 @@
 # Export TOB-WGS dataset to PLINK format
 
-This runs a Hail query script in Dataproc using Hail Batch in order to export the TOB-WGS genotypes, which are requirements for the association analysis. Only variants that pass VQSR and GQ filters are retained, as well as variants with an MAF > 0.01. To run, use conda to install the analysis-runner, then execute the following command:
+This runs a Hail query script in Dataproc using Hail Batch in order to export the TOB-WGS genotypes, which are requirements for the association analysis. Only variants that pass VQSR and GQ filters are retained, as well as variants with an MAF > 0.01. To run, use pip to install the analysis-runner, then execute the following command:
 
 ```sh
 analysis-runner --dataset tob-wgs \

--- a/scripts/generate_genotype_df/README.md
+++ b/scripts/generate_genotype_df/README.md
@@ -1,0 +1,9 @@
+# Export TOB-WGS dataset to PLINK format
+
+This runs a Hail query script in Dataproc using Hail Batch in order to export the TOB-WGS genotypes, which are requirements for the association analysis. Only variants that pass VQSR and GQ filters are retained, as well as variants with an MAF > 0.01. To run, use conda to install the analysis-runner, then execute the following command:
+
+```sh
+analysis-runner --dataset tob-wgs \
+--access-level standard --output-dir "tob_wgs_plink_maf01/v0" \
+--description "TOB plink" python3 main.py
+```

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -25,7 +25,7 @@ def query():
     # filter out variants with MAF < 0.01
     mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
     tob_wgs_path = output_path('tob_wgs_maf01.parquet')
-    mt.rows().to_spark().write.mode("append").parquet(tob_wgs_path)
+    mt.rows().to_spark().write.mode('append').parquet(tob_wgs_path)
 
 if __name__ == '__main__':
     query()

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -3,23 +3,29 @@
 """Generate genotype dfs for the association analysis"""
 
 import hail as hl
+from analysis_runner import bucket_path, output_path
 
-TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v7.mt/'
+TOB_WGS = bucket_path('mt/v7.mt/')
 
-hl.init(default_reference='GRCh38')
+def query():
+    """Query script entry point."""
 
-mt = hl.read_matrix_table(TOB_WGS)
-# filter out variants that didn't pass the VQSR filter
-mt = mt.filter_rows(hl.is_missing(mt.filters))
-# VQSR does not filter out low quality genotypes. Filter these out
-mt = mt.filter_entries(mt.GQ <= 20, keep = False)
-# filter out samples with a genotype call rate > 0.8 
-n_samples = mt.count_cols()
-call_rate = 0.8
-mt = mt.filter_rows(hl.agg.sum(hl.is_missing(mt.GT)) > (n_samples * call_rate), keep=False)
-# filter out variants with MAF < 0.01
-mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
-# turn files into output that we need
-# turn into plink, split up by chromosome
+    hl.init(default_reference='GRCh38')
 
+    mt = hl.read_matrix_table(TOB_WGS)
+    # filter out variants that didn't pass the VQSR filter
+    mt = mt.filter_rows(hl.is_missing(mt.filters))
+    # VQSR does not filter out low quality genotypes. Filter these out
+    mt = mt.filter_entries(mt.GQ <= 20, keep = False)
+    # filter out samples with a genotype call rate > 0.8 
+    n_samples = mt.count_cols()
+    call_rate = 0.8
+    mt = mt.filter_rows(hl.agg.sum(hl.is_missing(mt.GT)) > (n_samples * call_rate), keep=False)
+    # filter out variants with MAF < 0.01
+    mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
+    # export as PLINK file
+    tob_wgs_path = output_path('tob_wgs_plink_maf01')
+    hl.export_plink(mt, tob_wgs_path, ind_id=mt.s)
 
+if __name__ == '__main__':
+    query()

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -24,7 +24,6 @@ def query():
     mt = mt.filter_rows(hl.agg.sum(hl.is_missing(mt.GT)) > (n_samples * call_rate), keep=False)
     # filter out variants with MAF < 0.01
     mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
-    # export as PLINK file
     tob_wgs_path = output_path('tob_wgs_maf01.parquet')
     mt.rows().to_spark().write.mode("append").parquet(tob_wgs_path)
 

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -17,7 +17,7 @@ def query():
     mt = mt.filter_rows(hl.len(hl.or_else(mt.filters, hl.empty_set(hl.tstr))) == 0)
 
     # VQSR does not filter out low quality genotypes. Filter these out
-    mt = mt.filter_entries(mt.GQ <= 20, keep = False)
+    mt = mt.filter_entries(mt.GQ <= 20, keep=False)
     # filter out samples with a genotype call rate > 0.8 (as in the gnomAD supplementary paper)
     n_samples = mt.count_cols()
     call_rate = 0.8

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""Generate genotype dfs for the association analysis"""
+
+import hail as hl
+
+TOB_WGS = 'gs://cpg-tob-wgs-test/mt/v7.mt/'
+
+hl.init(default_reference='GRCh38')
+
+mt = hl.read_matrix_table(TOB_WGS)
+# filter out variants that didn't pass the VQSR filter
+mt = mt.filter_rows(hl.is_missing(mt.filters))
+# VQSR does not filter out low quality genotypes. Filter these out
+mt = mt.filter_entries(mt.GQ <= 20, keep = False)
+# filter out samples with a genotype call rate > 0.8 
+n_samples = mt.count_cols()
+call_rate = 0.8
+mt = mt.filter_rows(hl.agg.sum(hl.is_missing(mt.GT)) > (n_samples * call_rate), keep=False)
+# filter out variants with MAF < 0.01
+mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
+# turn files into output that we need
+# turn into plink, split up by chromosome
+
+

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -25,7 +25,7 @@ def query():
     # filter out variants with MAF < 0.01
     mt = mt.filter_rows(mt.freq.AF[1] > 0.01)
     tob_wgs_path = output_path('tob_wgs_maf01.parquet')
-    mt.rows().to_spark().write.mode('append').parquet(tob_wgs_path)
+    mt.rows().to_pandas()[['locus.contig','locus.position','alleles']].to_parquet(tob_wgs_path)
 
 if __name__ == '__main__':
     query()

--- a/scripts/generate_genotype_df/generate_genotype_df.py
+++ b/scripts/generate_genotype_df/generate_genotype_df.py
@@ -17,7 +17,7 @@ def query():
     mt = mt.filter_rows(hl.is_missing(mt.filters))
     # VQSR does not filter out low quality genotypes. Filter these out
     mt = mt.filter_entries(mt.GQ <= 20, keep = False)
-    # filter out samples with a genotype call rate > 0.8 
+    # filter out samples with a genotype call rate > 0.8 (as in the gnomAD supplementary paper)
     n_samples = mt.count_cols()
     call_rate = 0.8
     mt = mt.filter_rows(hl.agg.sum(hl.is_missing(mt.GT)) > (n_samples * call_rate), keep=False)

--- a/scripts/generate_genotype_df/main.py
+++ b/scripts/generate_genotype_df/main.py
@@ -1,0 +1,23 @@
+"""Entry point for the analysis runner."""
+
+import os
+import hailtop.batch as hb
+from analysis_runner import dataproc
+
+service_backend = hb.ServiceBackend(
+    billing_project=os.getenv('HAIL_BILLING_PROJECT'), bucket=os.getenv('HAIL_BUCKET')
+)
+
+batch = hb.Batch(name='export_genotype_data', backend=service_backend)
+
+dataproc.hail_dataproc_job(
+    batch,
+    f'generate_genotype_df.py',
+    max_age='4h',
+    num_secondary_workers=20,
+    init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
+    job_name=f'export_genotype_data',
+    worker_boot_disk_size=200,
+)
+
+batch.run()

--- a/scripts/generate_genotype_df/main.py
+++ b/scripts/generate_genotype_df/main.py
@@ -12,7 +12,7 @@ batch = hb.Batch(name='export_genotype_data', backend=service_backend)
 
 dataproc.hail_dataproc_job(
     batch,
-    f'generate_genotype_df.py',
+    'generate_genotype_df.py',
     max_age='4h',
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name='export_genotype_data',

--- a/scripts/generate_genotype_df/main.py
+++ b/scripts/generate_genotype_df/main.py
@@ -15,7 +15,7 @@ dataproc.hail_dataproc_job(
     f'generate_genotype_df.py',
     max_age='4h',
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
-    job_name=f'export_genotype_data',
+    job_name='export_genotype_data',
 )
 
 batch.run()

--- a/scripts/generate_genotype_df/main.py
+++ b/scripts/generate_genotype_df/main.py
@@ -14,10 +14,8 @@ dataproc.hail_dataproc_job(
     batch,
     f'generate_genotype_df.py',
     max_age='4h',
-    num_secondary_workers=20,
     init=['gs://cpg-reference/hail_dataproc/install_common.sh'],
     job_name=f'export_genotype_data',
-    worker_boot_disk_size=200,
 )
 
 batch.run()


### PR DESCRIPTION
This generates a genotype file to Plink format to be used in the association analysis. Only  variants with an MAF > 0.01 are retained + additional filtering for passing VQSR filters, GQ, and missingness. This has run [successfully](https://batch.hail.populationgenomics.org.au/batches/8390/jobs/2) in the `test` bucket.