### PR TITLE
Change access level to 'standard' if bucket name is 'main'

### DIFF
--- a/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
@@ -129,6 +129,8 @@ def submit_eqtl_jobs(
                 analysis_runner_output_path = output_prefix[5:].partition('/')[-1]
                 # get access level from bucket, rather than manual input
                 access_level = bucket_name.split('-')[-1]
+                if access_level == 'main':
+                    access_level = 'standard'
                 run_analysis_runner(
                     description=f'eqtl_spearman_{cell_type}_chr{chromosome}',
                     dataset='tob-wgs',


### PR DESCRIPTION
Previously, I was testing data using the `test` bucket, however found a mistake when running in `main`. 

Data access can be either `standard`, `full`, or `test`. When previously running the script, I used the gs://cpg-<dataset>-{main,test} syntax, using `test` as the access level. However, this does not work for main, as access levels are `standard` or `full`. 