### PR TITLE
Repartition mt after filtering and checkpoint to speed up analysis

### DIFF
--- a/scripts/eqtl_hail_batch/conditional_analysis.py
+++ b/scripts/eqtl_hail_batch/conditional_analysis.py
@@ -11,7 +11,6 @@ from patsy import dmatrices  # pylint: disable=no-name-in-module
 from scipy.stats import spearmanr
 from cpg_utils.hail_batch import (
     dataset_path,
-    output_path,
     copy_common_env,
     init_batch,
     remote_tmpdir,
@@ -81,7 +80,7 @@ def prepare_genotype_info(keys_path):
         mt = mt.filter_entries(mt.GQ <= 20, keep=False)
         # filter out samples with a genotype call rate > 0.8 (as in the gnomAD supplementary paper)
         # checkpoint the mt so that it isn't evaluated multiple times
-        mt = mt.checkpoint(output_path('genotype_table_checkpoint.mt', 'tmp'))
+        mt = mt.checkpoint(dataset_path('scrna-seq/genotype_table_checkpoint.mt', 'tmp'))
         n_samples = mt.count_cols()
         call_rate = 0.8
         mt = mt.filter_rows(

--- a/scripts/eqtl_hail_batch/conditional_analysis.py
+++ b/scripts/eqtl_hail_batch/conditional_analysis.py
@@ -64,12 +64,11 @@ def prepare_genotype_info(keys_path):
     Returns:
     Path to a hail matrix table, with rows (alleles) filtered on the following requirements:
     1) biallelic, 2) meets VQSR filters, 3) gene quality score higher than 20,
-    4) call rate of 0.8, and 5) variants with MAF <= 0.01. Columns (samples) are filtered
-    on the basis of having rna-seq expression data, i.e., within the filtered log_expression_df
+    4) call rate of 0.8, and 5) variants with MAF <= 0.01.
     """
 
     init_batch()
-    filtered_mt_path = output_path('genotype_table.mt', 'tmp')
+    filtered_mt_path = dataset_path('scrna-seq/genotype_table.mt', 'tmp')
     if not hl.hadoop_exists(filtered_mt_path):
         mt = hl.read_matrix_table(TOB_WGS)
         mt = mt.naive_coalesce(10000)
@@ -107,7 +106,7 @@ def prepare_genotype_info(keys_path):
         sampleid_keys = sampleid_keys.key_by('sampleid')
         mt = mt.annotate_cols(onek1k_id=sampleid_keys[mt.s].OneK1K_ID)
         # repartition to save overhead cost
-        mt = mt.naive_coalesce(100)
+        mt = mt.naive_coalesce(1000)
         mt.write(filtered_mt_path)
 
     return filtered_mt_path

--- a/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
@@ -13,7 +13,6 @@ from patsy import dmatrices  # pylint: disable=no-name-in-module
 from scipy.stats import spearmanr
 from cpg_utils.hail_batch import (
     dataset_path,
-    output_path,
     copy_common_env,
     init_batch,
     remote_tmpdir,
@@ -207,7 +206,7 @@ def prepare_genotype_info(keys_path):
         mt = mt.filter_entries(mt.GQ <= 20, keep=False)
         # filter out samples with a genotype call rate > 0.8 (as in the gnomAD supplementary paper)
         # checkpoint the mt so that it isn't evaluated multiple times
-        mt = mt.checkpoint(output_path('genotype_table_checkpoint.mt', 'tmp'))
+        mt = mt.checkpoint(dataset_path('scrna-seq/genotype_table_checkpoint.mt', 'tmp'))
         n_samples = mt.count_cols()
         call_rate = 0.8
         mt = mt.filter_rows(


### PR DESCRIPTION
As per the suggestions in [this slack thread](https://centrepopgen.slack.com/archives/C018KFBCR1C/p1658119554229409?thread_ts=1657849006.392169&cid=C018KFBCR1C) (and concerns over the analysis taking too long), I've added in a repartitioning step whenever I heavily filter the mt. I've also checkpointed the mt in the `prepare_genotype_info` so that it isn't evaluated multiple times. 

@lgruen , I'm not sure if naively repartitioning the mt to 100 partitions is too small (around line 250). Let me know what you think