### PR TITLE
Fix output path

### DIFF
--- a/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
@@ -13,6 +13,7 @@ from patsy import dmatrices  # pylint: disable=no-name-in-module
 from scipy.stats import spearmanr
 from cpg_utils.hail_batch import (
     dataset_path,
+    output_path,
     copy_common_env,
     init_batch,
     remote_tmpdir,
@@ -171,7 +172,7 @@ def generate_log_cpm_output(expression_df, output_prefix, celltype):
         data_summary.to_parquet(fp)
 
 
-def prepare_genotype_info(version, keys_path):
+def prepare_genotype_info(keys_path):
     """Filter hail matrix table
 
     Input:
@@ -185,7 +186,7 @@ def prepare_genotype_info(version, keys_path):
     """
 
     init_batch()
-    filtered_mt_path = dataset_path(f'scrna-seq/{version}/genotype_table.mt', 'tmp')
+    filtered_mt_path = output_path('genotype_table.mt', 'tmp')
     if hl.hadoop_exists(filtered_mt_path):
         return filtered_mt_path
     
@@ -200,7 +201,7 @@ def prepare_genotype_info(version, keys_path):
     mt = mt.filter_entries(mt.GQ <= 20, keep=False)
     # filter out samples with a genotype call rate > 0.8 (as in the gnomAD supplementary paper)
     # checkpoint the mt so that it isn't evaluated multiple times
-    mt = mt.checkpoint(dataset_path(f'scrna-seq/{version}/genotype_table_checkpoint.mt', 'tmp'))
+    mt = mt.checkpoint(output_path('genotype_table_checkpoint.mt', 'tmp'))
     n_samples = mt.count_cols()
     call_rate = 0.8
     mt = mt.filter_rows(
@@ -553,11 +554,11 @@ def main(
     Creates a Hail Batch pipeline for calculating EQTLs
     """
 
-    # get cell type info
+    # get cell type info and chromosome info
     celltype = expression.split('/')[-1].split('_expression')[0]
-
-    # get version info
-    version = output_prefix.split('/')[-1]
+    chromosome = geneloc.split('_')[-1].removesuffix('.tsv')
+    # rename output prefix to have chromosome and cell type
+    output_prefix = os.path.join(output_prefix, f'{celltype}', f'{chromosome}')
 
     backend = hb.ServiceBackend(billing_project=get_config()['hail']['billing_project'], remote_tmpdir=remote_tmpdir())
     batch = hb.Batch(name=celltype, backend=backend, default_python_image=get_config()['workflow']['driver_image'])
@@ -595,7 +596,7 @@ def main(
     filter_mt_job = batch.new_python_job('filter_mt')
     copy_common_env(filter_mt_job)
     filtered_mt_path = filter_mt_job.call(
-        prepare_genotype_info, version=version, keys_path=keys
+        prepare_genotype_info, keys_path=keys
     )
 
     for idx in range(n_genes_in_scatter):

--- a/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/generate_eqtl_spearman.py
@@ -322,7 +322,7 @@ def run_spearman_correlation_scatter(
     gene_info = geneloc_df.iloc[idx]
     chromosome = gene_info.chr
     # get all SNPs which are within 1Mb of each gene
-    init_batch(driver_cores=8)
+    init_batch(driver_cores=8, worker_cores=4)
     mt = hl.read_matrix_table(filtered_mt_path)
     # only keep samples that are contained within the residuals df
     # this is important, since not all individuals have expression/residual

--- a/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
@@ -44,13 +44,13 @@ from google.cloud import storage
     '--input-path',
     required=True,
     help=(
-        'A path prefix of where input files are located. Version number must be included on the end. eg: gs://MyBucket/folder/v0. '
+        'A path prefix of where input files are located. eg: gs://MyBucket/folder. '
     ),
 )
 @click.option(
     '--output-dir',
     required=True,
-    help='A path of where to output files. eg: gs://MyBucket/output-folder/',
+    help='A path of where to output files. Version number must be included on the end. eg: gs://MyBucket/output-folder/v0',
 )
 @click.option('--dry-run', is_flag=True, help='Just check if files exist')
 def submit_eqtl_jobs(
@@ -136,18 +136,13 @@ def submit_eqtl_jobs(
                 )
 
                 keys = os.path.join(input_path, 'OneK1K_CPG_IDs.tsv')
-                version = output_dir.split('/')[-1]
-                # put version number at end of output path
-                output_prefix = os.path.join(
-                    output_dir.strip(version), f'{cell_type}', f'chr{chromosome}', f'{version}'
-                )
                 job.command(
                     f'python3 scripts/eqtl_hail_batch/generate_eqtl_spearman.py '
                     f'--expression {expression} '
                     f'--covariates {covariates} '
                     f'--geneloc {geneloc} '
                     f'--keys {keys} '
-                    f'--output-prefix {output_prefix}'
+                    f'--output-prefix {output_dir}'
                 )
 
     batch.run(wait=False)

--- a/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
@@ -44,13 +44,13 @@ from google.cloud import storage
     '--input-path',
     required=True,
     help=(
-        'A path prefix of where input files are located, eg: gs://MyBucket/folder/. '
+        'A path prefix of where input files are located. Version number must be included on the end. eg: gs://MyBucket/folder/v0. '
     ),
 )
 @click.option(
     '--output-dir',
     required=True,
-    help='A path of where to output files. Version number must be included on the end. eg: gs://MyBucket/output-folder/v0',
+    help='A path of where to output files. eg: gs://MyBucket/output-folder/',
 )
 @click.option('--dry-run', is_flag=True, help='Just check if files exist')
 def submit_eqtl_jobs(

--- a/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_generate_eqtl_spearman.py
@@ -50,7 +50,7 @@ from google.cloud import storage
 @click.option(
     '--output-dir',
     required=True,
-    help='A path of where to output files, eg: gs://MyBucket/output-folder/',
+    help='A path of where to output files. Version number must be included on the end. eg: gs://MyBucket/output-folder/v0',
 )
 @click.option('--dry-run', is_flag=True, help='Just check if files exist')
 def submit_eqtl_jobs(
@@ -136,8 +136,10 @@ def submit_eqtl_jobs(
                 )
 
                 keys = os.path.join(input_path, 'OneK1K_CPG_IDs.tsv')
+                version = output_dir.split('/')[-1]
+                # put version number at end of output path
                 output_prefix = os.path.join(
-                    output_dir, f'{cell_type}', f'chr{chromosome}'
+                    output_dir.strip(version), f'{cell_type}', f'chr{chromosome}', f'{version}'
                 )
                 job.command(
                     f'python3 scripts/eqtl_hail_batch/generate_eqtl_spearman.py '


### PR DESCRIPTION
I'm running into an issue where I would like to add a version number to my output files (in case a file gets corrupted/changes, etc) however I'm currently using `dataset_path` as the prefix of my output file, since `output_path` changes per cell type and I only need to generate this file once. I've added in a version to the output table, which is taken from the input-prefix.

@lgruen this is a crude way of fixing this. Please let me know if you think there's a better way