### PR TITLE
Pull cell types from PEER factors, as opposed to expression files

### DIFF
--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -1314,9 +1314,9 @@ def get_cell_types_from(input_files_prefix: str) -> list[str]:
     we can infer the cell types from the 'expression_files' subdirectory
         eg: {cell_type}_expression.tsv
     """
-    expression_files_dir = os.path.join(input_files_prefix, 'expression_files')
+    expression_files_dir = os.path.join(input_files_prefix, 'covariates_files')
     _logger.info(f'Going to fetch cell types from {expression_files_dir}')
-    ending = '_expression.tsv'
+    ending = '_peer_factors_file.txt'
     return [
         os.path.basename(fn)[: -len(ending)]
         for fn in list_dir(expression_files_dir, lambda el: el.endswith(ending))

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -1311,8 +1311,8 @@ def get_chromosomes(input_files_prefix: str):
 
 def get_cell_types_from(input_files_prefix: str) -> list[str]:
     """
-    we can infer the cell types from the 'expression_files' subdirectory
-        eg: {cell_type}_expression.tsv
+    we can infer the cell types from the 'covariates_files' subdirectory
+        eg: {cell_type}_peer_factors_file.tsv
     """
     expression_files_dir = os.path.join(input_files_prefix, 'covariates_files')
     _logger.info(f'Going to fetch cell types from {expression_files_dir}')

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -1315,7 +1315,7 @@ def get_cell_types_from(input_files_prefix: str) -> list[str]:
         eg: {cell_type}_peer_factors_file.tsv
     """
     covariates_files_dir = os.path.join(input_files_prefix, 'covariates_files')
-    _logger.info(f'Going to fetch cell types from {expression_files_dir}')
+    _logger.info(f'Going to fetch cell types from {covariates_files_dir}')
     ending = '_peer_factors_file.txt'
     return [
         os.path.basename(fn)[: -len(ending)]

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -1319,7 +1319,7 @@ def get_cell_types_from(input_files_prefix: str) -> list[str]:
     ending = '_peer_factors_file.txt'
     return [
         os.path.basename(fn)[: -len(ending)]
-        for fn in list_dir(expression_files_dir, lambda el: el.endswith(ending))
+        for fn in list_dir(covariates_files_dir, lambda el: el.endswith(ending))
     ]
 
 

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -1314,7 +1314,7 @@ def get_cell_types_from(input_files_prefix: str) -> list[str]:
     we can infer the cell types from the 'covariates_files' subdirectory
         eg: {cell_type}_peer_factors_file.tsv
     """
-    expression_files_dir = os.path.join(input_files_prefix, 'covariates_files')
+    covariates_files_dir = os.path.join(input_files_prefix, 'covariates_files')
     _logger.info(f'Going to fetch cell types from {expression_files_dir}')
     ending = '_peer_factors_file.txt'
     return [


### PR DESCRIPTION
As discussed in this [thread](https://centrepopgen.slack.com/archives/C01FBL6NWFN/p1664164414150339?thread_ts=1664149768.063269&cid=C01FBL6NWFN), cell types (if unspecified) are pulled from the expression files, however not all cell types have a successfully-generated PEER factor file. This is due to the fact that some cell types, such as ASDC and cDC1, have too few individuals in the expression data to succeed (see this post [here](https://centrepopgen.slack.com/archives/C01T0T41BHQ/p1646110730071539?thread_ts=1646101267.433209&cid=C01T0T41BHQ) from Seyhan Yazar). To mitigate this, I'm now pulling the cell type from the PEER factor files. 