### PR TITLE
Fix persist input

### DIFF
--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -584,7 +584,7 @@ def run_spearman_correlation_scatter(
     )
     mt = mt.filter_cols(samples_to_keep.contains(mt['onek1k_id']))
     # TODO: mfranklin to check mt.persist, as mt.rows() is called twice
-    mt = mt.persist(output_path(f'{chromosome}/{gene_name}.mt', 'tmp'))
+    mt = mt.persist('MEMORY_AND_DISK')
 
     position_table = mt.rows().select()
     position_table = position_table.annotate(


### PR DESCRIPTION
https://batch.hail.populationgenomics.org.au/batches/375537/jobs/1:

```
TypeError: persist: parameter 'storage_level': expected ('NONE' or 'DISK_ONLY' or 'DISK_ONLY_2' or 'MEMORY_ONLY' or 'MEMORY_ONLY_2' or 'MEMORY_ONLY_SER' or 'MEMORY_ONLY_SER_2' or 'MEMORY_AND_DISK' or 'MEMORY_AND_DISK_2' or 'MEMORY_AND_DISK_SER' or 'MEMORY_AND_DISK_SER_2' or 'OFF_HEAP'), found str: <output>/chr7/CNTNAP2.mt
```