### PR TITLE
Pre annotation filtering + fix previous query order

### DIFF
--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -575,6 +575,7 @@ def run_spearman_correlation_scatter(
     mt = hl.filter_intervals(
         mt, [hl.parse_locus_interval(first_and_last_snp, reference_genome='GRCh38')]
     )
+    mt = mt.filter_cols(samples_to_keep.contains(mt['onek1k_id']))
     # remove SNPs with no variance
     mt = mt.filter_rows(
         (hl.agg.all(mt.GT.n_alt_alleles() == 0))
@@ -582,7 +583,6 @@ def run_spearman_correlation_scatter(
         | (hl.agg.all(mt.GT.n_alt_alleles() == 2)),
         keep=False,
     )
-    mt = mt.filter_cols(samples_to_keep.contains(mt['onek1k_id']))
     mt = mt.persist('MEMORY_AND_DISK')
 
     position_table = mt.rows().select()

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -588,7 +588,8 @@ def run_spearman_correlation_scatter(
         keep=False,
     )
     mt = mt.checkpoint(
-        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}.mt', 'tmp'), overwrite=True
+        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}.mt', 'tmp'),
+        overwrite=True,
     )
 
     position_table = mt.rows().select()

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -588,7 +588,7 @@ def run_spearman_correlation_scatter(
         keep=False,
     )
     mt = mt.checkpoint(
-        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}.mt', 'tmp'),
+        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}/spearman_correlation_scatter_filter.mt', 'tmp'),
         overwrite=True,
     )
 

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -622,7 +622,17 @@ def run_spearman_correlation_scatter(
 
     # Do this only on SNPs contained within gene_snp_df to save time
     snps_to_keep = hl.literal(set(gene_snp_df.snpid))
-    t = t.filter(snps_to_keep.contains(get_t_snp_id(t)))
+    t = t.filter(
+        snps_to_keep.contains(
+            hl.str(t.locus.contig)
+            + ':'
+            + hl.str(t.locus.position)
+            + ':'
+            + hl.str(t.alleles[0])
+            + ':'
+            + hl.str(t.alleles[1])
+        )
+    )
 
     # hopefully we've filtered enough now we can annotate
 
@@ -634,7 +644,16 @@ def run_spearman_correlation_scatter(
         global_bp=t.locus.global_position(),
         a1=t.alleles[0],
         a2=t.alleles[1],
-        snpid=get_t_snp_id(t),
+    )
+
+    t = t.annotate(
+        snpid=hl.str(t.contig)
+        + ':'
+        + hl.str(t.position)
+        + ':'
+        + hl.str(t.a1)
+        + ':'
+        + hl.str(t.a2)
     )
 
     # only keep SNPs where all samples have an alt_allele value

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -714,7 +714,7 @@ def run_spearman_correlation_scatter(
 
         return pd.DataFrame.from_dict(snp_gt_summary_data)
 
-    association_effect_data = get_association_effect_data(gene_name)
+    association_effect_data = get_association_effect_data()
     # write association effect data
     association_effect_path = output_path(
         os.path.join(

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -634,8 +634,8 @@ def run_spearman_correlation_scatter(
         global_bp=t.locus.global_position(),
         a1=t.alleles[0],
         a2=t.alleles[1],
+        snpid=get_t_snp_id(t),
     )
-    t = t.annotate(snpid=get_t_snp_id(t))
 
     # only keep SNPs where all samples have an alt_allele value
     # (argument must be a string, a bytes-like object or a number)

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -650,12 +650,12 @@ def run_spearman_correlation_scatter(
 
     # Get association effect data, to be used for violin plots for each genotype of each SNP
     # TODO: remove redefined gene function param
-    def get_association_effect_data(gene):
+    def get_association_effect_data():
         sampleid = expression_df.sampleid
         log_cpm = calculate_log_cpm(expression_df)
         log_cpm['sampleid'] = sampleid
         # reduce log_cpm matrix to gene of interest only
-        log_cpm = log_cpm[['sampleid', gene]]
+        log_cpm = log_cpm[['sampleid', gene_name]]
         # merge log_cpm data with genotype info
         gt_expr_data = genotype_df.merge(
             log_cpm, left_on='sampleid', right_on='sampleid'
@@ -663,13 +663,13 @@ def run_spearman_correlation_scatter(
         # group gt_expr_data by snpid and genotype
         grouped_gt = gt_expr_data.groupby(['snpid', 'n_alt_alleles'])
 
-        def create_struct(gene, group):
-            hist, bin_edges = np.histogram(group[gene], bins=10)
-            n_samples = group[gene].count()
-            min_val = group[gene].min()
-            max_val = group[gene].max()
-            mean_val = group[gene].mean()
-            q1, median_val, q3 = group[gene].quantile([0.25, 0.5, 0.75])
+        def create_struct(_group):
+            hist, bin_edges = np.histogram(_group[gene_name], bins=10)
+            n_samples = _group[gene_name].count()
+            min_val = _group[gene_name].min()
+            max_val = _group[gene_name].max()
+            mean_val = _group[gene_name].mean()
+            q1, median_val, q3 = _group[gene_name].quantile([0.25, 0.5, 0.75])
             iqr = q3 - q1
             data_struct = {
                 'bin_counts': hist,
@@ -706,9 +706,9 @@ def run_spearman_correlation_scatter(
                     'global_bp': global_bp,
                     'genotype': genotype,
                     'gene_id': gene_id,
-                    'gene_symbol': gene,
+                    'gene_symbol': gene_name,
                     'cell_type_id': cell_type,
-                    'struct': create_struct(gene, group),
+                    'struct': create_struct(group),
                 }
             )
 

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -622,17 +622,7 @@ def run_spearman_correlation_scatter(
 
     # Do this only on SNPs contained within gene_snp_df to save time
     snps_to_keep = hl.literal(set(gene_snp_df.snpid))
-    t = t.filter(
-        snps_to_keep.contains(
-            hl.str(t.locus.contig)
-            + ':'
-            + hl.str(t.locus.position)
-            + ':'
-            + hl.str(t.alleles[0])
-            + ':'
-            + hl.str(t.alleles[1])
-        )
-    )
+    t = t.filter(snps_to_keep.contains(get_t_snp_id(t)))
 
     # hopefully we've filtered enough now we can annotate
 
@@ -644,16 +634,7 @@ def run_spearman_correlation_scatter(
         global_bp=t.locus.global_position(),
         a1=t.alleles[0],
         a2=t.alleles[1],
-    )
-
-    t = t.annotate(
-        snpid=hl.str(t.contig)
-        + ':'
-        + hl.str(t.position)
-        + ':'
-        + hl.str(t.a1)
-        + ':'
-        + hl.str(t.a2)
+        snpid=get_t_snp_id(t),
     )
 
     # only keep SNPs where all samples have an alt_allele value

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -611,13 +611,13 @@ def run_spearman_correlation_scatter(
     # table, then mostly discarding - hopefully should save memory
     def get_t_snp_id(_t):
         return (
-            hl.str(_t.contig)
+            hl.str(_t.locus.contig)
             + ':'
-            + hl.str(_t.position)
+            + hl.str(_t.locus.position)
             + ':'
-            + hl.str(_t.a1)
+            + hl.str(_t.alleles[0])
             + ':'
-            + hl.str(_t.a2)
+            + hl.str(_t.alleles[1])
         )
 
     # Do this only on SNPs contained within gene_snp_df to save time

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -649,7 +649,6 @@ def run_spearman_correlation_scatter(
     gene_snp_df = gene_snp_df[gene_snp_df.snpid.isin(set(genotype_df.snpid))]
 
     # Get association effect data, to be used for violin plots for each genotype of each SNP
-    # TODO: remove redefined gene function param
     def get_association_effect_data():
         sampleid = expression_df.sampleid
         log_cpm = calculate_log_cpm(expression_df)

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -587,7 +587,9 @@ def run_spearman_correlation_scatter(
         | (hl.agg.all(mt.GT.n_alt_alleles() == 2)),
         keep=False,
     )
-    mt = mt.persist('MEMORY_AND_DISK')
+    mt = mt.checkpoint(
+        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}.mt', 'tmp'), overwrite=True
+    )
 
     position_table = mt.rows().select()
     position_table = position_table.annotate(


### PR DESCRIPTION
- Minor cleanup of `get_association_effect_data`
- Filter on computed snp_id to avoid annotating whole table + save memory
- Reorder `filter_cols` from #127 to preserve _filtering on rows with a certain variance_ (_outlier sample that has high variance, that SNP will be retained, but if you filter out that sample you’ll have a different subset of variants_) @KatalinaBobowik.

I've checked, and results are identical again - but now using less memory. I think this is ready to test on full scale `chr7:CNTNAP2`.