### PR TITLE
More JVM memory tuning

### DIFF
--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -561,7 +561,7 @@ def run_spearman_correlation_scatter(
     # perform correlation in chunks by gene
 
     # get all SNPs which are within 1Mb of each gene
-    init_batch(driver_cores=8, driver_memory='highmem')
+    init_batch(driver_cores=8, driver_memory='highmem', worker_memory='highmem')
     mt = hl.read_matrix_table(filtered_mt_path)
     # only keep samples that are contained within the residuals df
     # this is important, since not all individuals have expression/residual

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -411,7 +411,7 @@ def generate_log_cpm_output(
     # add in cell type info
     data_summary['cell_type_id'] = cell_type
     # add in ENSEMBL IDs
-    init_batch(driver_cores=8)
+    init_batch(driver_cores=2)
     gtf = hl.experimental.import_gtf(
         gencode_gtf_path, reference_genome='GRCh38', skip_invalid_contigs=True
     )

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -561,7 +561,9 @@ def run_spearman_correlation_scatter(
     # perform correlation in chunks by gene
 
     # get all SNPs which are within 1Mb of each gene
-    init_batch(driver_cores=8, driver_memory='highmem', worker_memory='highmem')
+    init_batch(
+        driver_cores=2, driver_memory='highmem', worker_cores=2, worker_memory='highmem'
+    )
     mt = hl.read_matrix_table(filtered_mt_path)
     # only keep samples that are contained within the residuals df
     # this is important, since not all individuals have expression/residual
@@ -587,7 +589,10 @@ def run_spearman_correlation_scatter(
         keep=False,
     )
     mt = mt.checkpoint(
-        output_path(f'eqtl/{cell_type}/{chromosome}/{gene_name}/spearman_correlation_scatter_filter.mt', 'tmp'),
+        output_path(
+            f'eqtl/{cell_type}/{chromosome}/{gene_name}/spearman_correlation_scatter_filter.mt',
+            'tmp',
+        ),
         overwrite=True,
     )
 

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -561,9 +561,7 @@ def run_spearman_correlation_scatter(
     # perform correlation in chunks by gene
 
     # get all SNPs which are within 1Mb of each gene
-    init_batch(
-        driver_cores=2, driver_memory='highmem', worker_cores=2, worker_memory='highmem'
-    )
+    init_batch(driver_cores=2, worker_cores=2)
     mt = hl.read_matrix_table(filtered_mt_path)
     # only keep samples that are contained within the residuals df
     # this is important, since not all individuals have expression/residual


### PR DESCRIPTION
Trying to reduce to two `standard` cores for driver / worker JVMs, which [succeeds for `chr22:ADA2`](https://batch.hail.populationgenomics.org.au/batches/376434), but it might fail on `chr7:CNTNAP2`. In that case we'll have to bump this up a bit, probably by switching to 2 `highmem` cores.

@illusional's original comment:

> Failing at:
> 
> - https://batch.hail.populationgenomics.org.au/batches/376101/jobs/1 (to)
> - https://batch.hail.populationgenomics.org.au/batches/376142/jobs/2
> 
> Hopefully this gets through, otherwise will have to bump driver_cores to 8, and probably keep standard memory.