### PR TITLE
Switch worker memory to highmem

### DIFF
--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -561,7 +561,7 @@ def run_spearman_correlation_scatter(
     # perform correlation in chunks by gene
 
     # get all SNPs which are within 1Mb of each gene
-    init_batch(driver_cores=2, worker_cores=2)
+    init_batch(driver_cores=2, worker_cores=2, worker_memory='highmem')
     mt = hl.read_matrix_table(filtered_mt_path)
     # only keep samples that are contained within the residuals df
     # this is important, since not all individuals have expression/residual


### PR DESCRIPTION
Example failure for `chr7:CNTNAP2`: https://batch.hail.populationgenomics.org.au/batches/376501/jobs/2