### PR TITLE
avoid write directly to release

### DIFF
--- a/scripts/subset_crams.py
+++ b/scripts/subset_crams.py
@@ -68,13 +68,12 @@ def main(beds: str):
 
     # set the image and reference to use
     samtools_image = get_config()['images']['samtools']
-    cram_reference = get_config()['references']['broad']['ref_fasta']
 
     # let's start up a hail batch!
     batch = get_batch('Generate CRAM subsets - tob-wgs')
 
     # read reference in once per batch
-    batch_reference = batch.read_input(cram_reference)
+    batch_reference = batch.read_input('gs://cpg-common-main/references/hg38/v0/Homo_sapiens_assembly38.fasta')
 
     # iterate over  all samples & BED files
     for ext_id, bed_file in ext_ids.items():


### PR DESCRIPTION
Hail Batch doesn't have permission to write directly into `-release`, as this requires a billing user to be set during the write.

Also explicitly sets the reference genome for these CRAMs - required a bit of searching through Slack threads to find the correct one, which then had to be overridden using a bespoke config...

https://centrepopgen.slack.com/archives/C030X7WGFCL/p1669181374517279?thread_ts=1669180382.708679&cid=C030X7WGFCL