### PR TITLE
release minified CRAM data

### DIFF
--- a/scripts/data_transfer/copy_mini_crams_2023_01_30.sh
+++ b/scripts/data_transfer/copy_mini_crams_2023_01_30.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+gcloud storage --billing-project tob-wgs cp --recursive \
+    gs://cpg-tob-wgs-main/MRR_cram_extracts/2023_01_30 \
+    gs://cpg-tob-wgs-release/MRR_cram_extracts/2023_01_30


### PR DESCRIPTION
Script for copying the mini CRAM files in `main` into `release`, as the `tob-wgs` user