### PR TITLE
update to use GCS files without copying

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
     python: python3.10
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.2.0'
+  rev: 'v4.4.0'
   hooks:
   - id: check-yaml
     exclude: '\.*conda/.*'
@@ -13,7 +13,7 @@ repos:
   - id: check-added-large-files
 
 - repo: https://github.com/PyCQA/flake8
-  rev: '5.0.4'
+  rev: '6.0.0'
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear, flake8-quotes]
@@ -28,6 +28,6 @@ repos:
 
 # Static type analysis (as much as it's possible in python using type hints)
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v0.960'
+  rev: 'v1.0.1'
   hooks:
   - id: mypy

--- a/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
+++ b/scripts/eqtl_hail_batch/launch_eqtl_spearman.py
@@ -14,6 +14,11 @@ For example:
         --chromosomes '1 2' \
         --genes B_intermediate
 """
+
+
+#  pylint: disable=unsupported-assignment-operation,unsubscriptable-object
+
+
 import os
 import logging
 
@@ -1102,9 +1107,9 @@ def calculate_conditional_residuals(
             model = sm.OLS(y, x)
             residuals = list(model.fit().resid)
             return residuals
-        except Exception as e:
+        except Exception as e:  # pylint: disable=broad-except
             logger.info(f'y = {y}, x = {x}')
-            raise Exception(
+            raise ValueError(
                 f'Error during calculate_adjusted_residuals for {gene_id}'
             ) from e
 

--- a/scripts/peer/peer.py
+++ b/scripts/peer/peer.py
@@ -38,7 +38,7 @@ def get_covariates(
     """
     # load in scores which have outliers removed
     scores_df: pd.DataFrame = pd.read_json(scores_path)
-    sampleid = scores_df.s
+    sampleid = scores_df.s  # pylint: disable=no-member
     # only get the first 4 PCs, as indicated by scree plot
     scores = pd.DataFrame(scores_df['scores'].to_list()).iloc[:, 0:4]
     scores.columns = ['PC1', 'PC2', 'PC3', 'PC4']

--- a/scripts/peer/peer.py
+++ b/scripts/peer/peer.py
@@ -25,6 +25,7 @@ import pandas as pd
 from cpg_utils.hail_batch import remote_tmpdir, output_path
 from google.cloud import storage
 
+
 PEER_DOCKER = 'australia-southeast1-docker.pkg.dev/cpg-common/images/peer:1.3.2'
 
 
@@ -36,7 +37,7 @@ def get_covariates(
     Only needs to be run once. This returns a TSV (as a string)
     """
     # load in scores which have outliers removed
-    scores_df = pd.read_json(scores_path)
+    scores_df: pd.DataFrame = pd.read_json(scores_path)
     sampleid = scores_df.s
     # only get the first 4 PCs, as indicated by scree plot
     scores = pd.DataFrame(scores_df['scores'].to_list()).iloc[:, 0:4]

--- a/scripts/rv_expression_association/count_variants.py
+++ b/scripts/rv_expression_association/count_variants.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-module-docstring,missing-function-docstring,no-value-for-parameter,import-error,no-name-in-module
+# pylint: disable=no-value-for-parameter,import-error,no-name-in-module
 
-# This script aims to count the total number of variants (non-ref)
-# from the whole TOB-WGS dataset that are biallelic SNVs
-# and rare (MAF < 5%)
+
+"""
+This script aims to count the total number of variants (non-ref)
+from the whole TOB-WGS dataset that are biallelic SNVs
+and rare (MAF < 5%)
+"""
 
 import click
 import hail as hl
@@ -12,9 +15,11 @@ from cpg_utils.hail_batch import dataset_path, init_batch
 
 @click.command()
 @click.option('--mt-path', required=True)  # 'mt/v7.mt'
-def count_variants(
-    mt_path: str,
-):
+def count_variants(mt_path: str):
+    """
+    reads the MT, conducts QC filtering, and prints the nuber
+    of remaining variants
+    """
     # read hail matrix table object (WGS data)
     init_batch()
     mt = hl.read_matrix_table(dataset_path(mt_path))


### PR DESCRIPTION
Update to use direct access of GCS CRAMs rather than copy-in

Prior to merging, intent is to tidy up some linting errors