### PR TITLE
Enrich tob/bioheart metadata with sequencing dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ nogit
 *.xlsx
 *.csv
 *.txt
+*.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nogit
 .idea
 *.xlsx
 *.csv
+*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nogit
 .DS_Store
 .idea
+*.xlsx

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nogit
 .DS_Store
 .idea
 *.xlsx
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ nogit
 *.csv
 *.txt
 *.ipynb
+*.fastq.gz

--- a/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
+++ b/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
@@ -1,0 +1,61 @@
+from collections import defaultdict
+
+from metamist.apis import AssayApi
+from metamist.graphql import gql, query
+from metamist.models import AssayUpsert
+
+QUERY = gql(
+    """
+        query MyQuery {
+            project(name: "tob-wgs-dev") {
+                participants {
+                id
+                samples {
+                    assays {
+                        id
+                    }
+                }
+                }
+            }
+        }
+    """,
+)
+
+
+def get_data_metamist():
+    participants = query(QUERY)['project']['participants']
+    list_assays = defaultdict(list)
+
+    for participant in participants:
+        for sample in participant['samples']:
+            list_assays[participant['id']].append(sample['assays'][0]['id'])
+
+    return list_assays
+
+
+def upsert_tube_ids(list_participants: defaultdict):
+    print(
+        'list_participants is hard coded in the function. Ensure dummy_tube keys are representative of participants in list',
+    )
+    print(list_participants)
+    aapi = AssayApi()
+    # Create dictionary containing dummy tube IDs
+    dummy_tubes = {
+        1368: 'FDS1000000000',
+        1369: 'FDS1000000001',
+        1370: 'FDS1000000002',
+        1371: 'FDS1000000003',
+        1372: 'FDS1000000004',
+    }
+
+    for key, tube in dummy_tubes.items():
+        new_assay = AssayUpsert()
+        new_assay['id'] = key
+        new_assay['meta'] = {}
+        new_assay['meta']['kgcc_tube_id'] = tube
+        aapi.update_assay(assay_upsert=new_assay)
+
+
+if __name__ == ('__main__'):
+    list_participants = get_data_metamist()
+    upsert_tube_ids(list_participants)

--- a/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
+++ b/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
@@ -52,7 +52,7 @@ def upsert_tube_ids(list_participants: defaultdict):
         new_assay = AssayUpsert()
         new_assay['id'] = key
         new_assay['meta'] = {}
-        new_assay['meta']['kgcc_tube_id'] = tube
+        new_assay['meta']['KCCG FluidX tube ID'] = tube
         aapi.update_assay(assay_upsert=new_assay)
 
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -188,6 +188,10 @@ def compare_tubes_metamist_excel(
     fluidx_to_assay_ids: defaultdict,
     fluidx_to_sequencing_date: dict,
 ):
+    """
+    Includes diagnostic code used to identify tubes missing between metamist and the
+    provided sequencing date manifests. Prints output to console.
+    """
     # Create a set from the fluidX identifiers only that were extracted from metamist
     metamist_set_fluidx = set(fluidx_to_assay_ids.keys())
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -1,0 +1,68 @@
+# We need metamist query and parsing for excel file
+
+from metamist.graphql import query, gql
+from collections import defaultdict
+import pandas as pd
+from metamist.apis import AssayApi
+from metamist.models import AssayUpsert
+
+# Get what we want out of metamist
+QUERY = gql(
+    """
+    query enrich_tob_seq_date {
+    project(name: "tob-wgs") {
+        samples {
+            externalId
+            meta
+            assays {
+                id
+                meta
+            }
+        }
+        }
+    }
+    """)
+
+# gives us json output as seen in graphql interface as dictionary
+query_result = query(QUERY)
+
+# list full of dictionaries of samples 
+tob_samples = query_result['project']['samples']
+
+assays = []
+for sample in tob_samples:
+   assays.extend(sample.get('assays'))
+
+fluidX_to_assay_IDs = defaultdict(list)
+for assay in assays:
+   # extract assay ID and fluid X tubeID
+   # fluid tube id is the key; list contains assay IDs
+   fluidX_tube_id = assay.get('meta').get('KCCG FluidX tube ID')
+   fluidX_to_assay_IDs[fluidX_tube_id].append(assay.get('id'))
+
+tob_sheet_names = [] # Make list
+
+# For all sheets listed in tob_sheet_names and bioheart_sheet_names
+for sheet in tob_sheet_names:
+   df_sheet_index = pd.read_excel('sample.xlsx', sheet_name=sheet)
+
+   # Start with blank dataframe and stack each sheet onto the end: make a giant dataframe
+   # for column 1, rip off the accession date (first 7 chars)
+   # Insert this value into a new dictionary fluidX_to_sequencing_date. Values are date values (whichever is easiest)
+
+# construct API update calls
+# Iterate through the fluidX_to_assay_IDs dictionary because this is what's already in metamist
+
+assay_API = AssayApi()
+
+for fluidX_id, assay_IDs in fluidX_to_assay_IDs.items(): 
+   # Get sequencing date for each fluidX id from our dictionary that doesn't exist yet
+    date = 00000000
+    for assay_id in assay_IDs:
+        # comment this out until you're ready to execute the script
+        # assay_API.update_assay(AssayUpsert(id=assay_id, meta={'sequencing_date': date}))
+        print("Validate content with print statements or move this into a notebook")
+
+# https://pythonbasics.org/read-excel/
+# https://github.com/populationgenomics/metamist/blob/dev/tob_metadata_harmonisation.py
+# update_assayAsync can let us bundle everything together. Develop script in 'snail way' and then adapt for batch/async implementation. 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -177,10 +177,10 @@ async def upsert_sequencing_dates(
                 print(f'Tube ID {fluidx_id} is not in the sequencing manifest')
             else:
                 for assay_id in assay_ids:
-                    updated_assay = AssayUpsert()
-                    updated_assay['id'] = assay_id
-                    updated_assay['meta'] = {}
-                    updated_assay['meta']['fluid_x_tube_sequencing_date'] = date
+                    updated_assay = AssayUpsert(
+                        id = assay_id,
+                        meta = {'fluid_x_tube_sequencing_date': date}
+                    )
                     assays_to_update.append(updated_assay)
                     print(f'API call added for {assay_id}')
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -166,10 +166,13 @@ async def upsert_sequencing_dates(
     fluidx_to_assay_ids: defaultdict,
     fluidx_to_sequencing_date: dict,
 ):
-    # construct API update calls
-    # Iterate through the fluidX_to_assay_IDs dictionary because this is representative of what's already in metamist
-    # That is: fluidX_to_assay_IDs groups assays by fluidX_tube_id
+    """
+    Upserts meta {'fluid_x_tube_sequencing_date: x'} for each fluidx tube in metamist.
+    Calls AssayUpsert endpoint update_assay_async with list of upserts: manages bulk calls asynchronously.
 
+    :return: Results from bulk API assay upsert calls
+    :rtype: Future
+    """
     assay_api = AssayApi()
     assays_to_update = []
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -202,50 +202,34 @@ def compare_tubes_metamist_excel(fluidX_to_assay_ids, fluidX_to_sequencing_date)
 def is_active_sequencing_group():
     query_result = query(QUERY_SEQ_GR_ACTIVE)
 
-    active_samples = query_result['project']['participants']
-    external_ids_to_active_assay_ids = defaultdict(list)
+    participants = query_result['project']['participants']
+    sequencing_group_to_active_assay_ids = defaultdict(list)
+    participants_without_sequencingGroup = []
 
-    participants = []
     # group all active samples by external ID
-    for participant in active_samples:
-        assay_ids = []
-        # participants.extend(participant.get('samples'))
-        external_id = participant.get('externalId')
+    for participant in participants:
+        sequencing_groups = []
+        # external_id = participant.get('externalId')
         # Get the id for all our active sequencing groups
-    #     assay_ids = participant.get('samples').get('sequencingGroups').get('assays').get('id')
-        assay_ids = participant.get('samples').get('sequencingGroups')
-        print(assay_ids)
-    #     for id in assay_ids:
-    #         # First, you need a list of all the 
-    #             external_ids_to_active_assay_ids[external_id].append(id)
-
-                
-    # for i in external_ids_to_active_assay_ids:
-    #     print(i)
-
-    # Create list of all assays from tob_samples (at an individual level)
-    # assays = []
-    # for sample in tob_samples:
-    #     assays.extend(sample.get('assays'))
-
-    # # Use default dict to group assays with fluid X tube metadata
-    # fluidX_to_assay_ids = defaultdict(list)
-    # for assay in assays:
-    #     # per assay, extract assay ID and fluid X tubeID
-    #     # fluid tube id is the key; list contains assay IDs
-    #     fluidX_tube_id = assay.get('meta').get('KCCG FluidX tube ID')
-    #     fluidX_to_assay_ids[fluidX_tube_id].append(assay.get('id'))
-
-
+        sequencing_groups = participant['samples'][0]['sequencingGroups']
+        try:
+            assays = sequencing_groups[0]['assays']
+            sequencing_group_id = sequencing_groups[0]['id']
+        except IndexError:
+            participants_without_sequencingGroup.append(participant['externalId'])
+        else:
+            for assay in assays:
+                sequencing_group_to_active_assay_ids[sequencing_group_id].append(assay['id'])
+    print(sequencing_group_to_active_assay_ids)
 
 if __name__ == '__main__':
-    fluidX_to_assay_ids = query_metamist()
-    if len(fluidX_to_assay_ids) != 0:
-        fluidX_to_sequencing_date = extract_excel()
-        # upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date)
-            # Exploration only 
-        compare_tubes_metamist_excel(fluidX_to_assay_ids, fluidX_to_sequencing_date)
-    else:
-        print('You have no FluidX_ids/assays to upsert')
+    # fluidX_to_assay_ids = query_metamist()
+    # if len(fluidX_to_assay_ids) != 0:
+    #     fluidX_to_sequencing_date = extract_excel()
+    #     # upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date)
+    #         # Exploration only 
+    #     compare_tubes_metamist_excel(fluidX_to_assay_ids, fluidX_to_sequencing_date)
+    # else:
+    #     print('You have no FluidX_ids/assays to upsert')
     
-    # is_active_sequencing_group()
+    is_active_sequencing_group()

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -232,6 +232,8 @@ async def main():
     fluidx_to_assay_ids = query_metamist()
     if len(fluidx_to_assay_ids) != 0:
         fluidx_to_sequencing_date = extract_excel()
+        # Uncomment this to compare the data in metamist to the manifests
+        # compare_tubes_metamist_excel(fluidx_to_assay_ids, fluidx_to_sequencing_date) #noqa: ERA001
         await upsert_sequencing_dates(
             fluidx_to_assay_ids,
             fluidx_to_sequencing_date,

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -143,16 +143,22 @@ def extract_excel():
     aggregated_df = pd.concat(df_list, ignore_index=True)
 
     # Separate accession date and fluidX_id in Sample Identifier column
-    aggregated_df['accession_date'] = aggregated_df['Sample Identifier'].apply(
-        lambda x: x.split('_')[0],
-    )
     aggregated_df['fluidX_id'] = aggregated_df['Sample Identifier'].apply(
         lambda x: x.split('_')[1],
     )
 
-    # Insert accession value into new dictionary fluidX_to_sequencing_date. Key is FluidX ID
+    # Convert date to format YYYY-MM-DD
+    aggregated_df['Date (YY/MM/DD)'] = pd.to_datetime(
+        aggregated_df['Date (YY/MM/DD)'],
+        format='%y%m%d',
+    )
+    aggregated_df['Date (YY/MM/DD)'] = aggregated_df['Date (YY/MM/DD)'].dt.strftime(
+        '%Y-%m-%d',
+    )
+
+    # Insert sequencing date value into new dictionary fluidX_to_sequencing_date. Key is FluidX ID
     return pd.Series(
-        aggregated_df.accession_date.values,
+        aggregated_df['Date (YY/MM/DD)'].values,
         index=aggregated_df.fluidX_id,
     ).to_dict()
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -1,12 +1,10 @@
-# We need metamist query and parsing for excel file
-
 from metamist.graphql import query, gql
 from collections import defaultdict
 import pandas as pd
 from metamist.apis import AssayApi
 from metamist.models import AssayUpsert
 
-# Get what we want out of metamist
+# Extract required data from metamist
 QUERY = gql(
     """
     query enrich_tob_seq_date {
@@ -23,45 +21,59 @@ QUERY = gql(
     }
     """)
 
-# gives us json output as seen in graphql interface as dictionary
+# gives us json output from graphql query 
+# Results are seen in graphql interface as a dictionary
 query_result = query(QUERY)
 
-# list full of dictionaries of samples 
+# list of dictionaries of samples per External ID
 tob_samples = query_result['project']['samples']
 
+# Create list of all assays from tob_samples (at an individual level)
 assays = []
 for sample in tob_samples:
    assays.extend(sample.get('assays'))
 
+# Use default dict to group assays with fluid X tube metadata
 fluidX_to_assay_IDs = defaultdict(list)
 for assay in assays:
-   # extract assay ID and fluid X tubeID
+   # per assay, extract assay ID and fluid X tubeID
    # fluid tube id is the key; list contains assay IDs
    fluidX_tube_id = assay.get('meta').get('KCCG FluidX tube ID')
    fluidX_to_assay_IDs[fluidX_tube_id].append(assay.get('id'))
 
-tob_sheet_names = [] # Make list
+tob_workbook_names = ['scripts/metadata_enrichment/1K1K Sequencing Dates.xlsx', 'scripts/metadata_enrichment/BioHEART Sequencing Dates.xlsx']
+# aggregated_df = pd.DataFrame()
+df_list = list()
 
-# For all sheets listed in tob_sheet_names and bioheart_sheet_names
-for sheet in tob_sheet_names:
-   df_sheet_index = pd.read_excel('sample.xlsx', sheet_name=sheet)
+# Amalgamate data in all sheets listed in tob_sheet_names and bioheart_sheet_names
+for workbook in tob_workbook_names:
+    df_sheet_index = pd.read_excel(workbook, sheet_name=None, header=0)
+    temp_df = pd.concat(df_sheet_index)
+    df_list.append(temp_df)
 
-   # Start with blank dataframe and stack each sheet onto the end: make a giant dataframe
-   # for column 1, rip off the accession date (first 7 chars)
-   # Insert this value into a new dictionary fluidX_to_sequencing_date. Values are date values (whichever is easiest)
+aggregated_df = pd.concat(df_list, ignore_index=True)
+# Separate accession date and fluidX_id
+aggregated_df['accession_date'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[0])
+aggregated_df['fluidX_id'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[1])
+
+# Insert accession value into new dictionary fluidX_to_sequencing_date. Key is FluidX ID
+fluidX_to_sequencing_date = pd.Series(aggregated_df.accession_date.values,index=aggregated_df.fluidX_id).to_dict()
 
 # construct API update calls
-# Iterate through the fluidX_to_assay_IDs dictionary because this is what's already in metamist
+# Iterate through the fluidX_to_assay_IDs dictionary because this is representative of what's already in metamist
+# That is: fluidX_to_assay_IDs groups assays by fluidX_tube_id
 
 assay_API = AssayApi()
 
-for fluidX_id, assay_IDs in fluidX_to_assay_IDs.items(): 
-   # Get sequencing date for each fluidX id from our dictionary that doesn't exist yet
-    date = 00000000
-    for assay_id in assay_IDs:
+for fluidX_id, assay_ids in fluidX_to_assay_IDs.items(): 
+    print(f'F ID: {fluidX_id}')
+   # Get sequencing date for each fluidX id from fluidX_to_sequencing_date dict
+    date = fluidX_to_sequencing_date[fluidX_id]
+    print(date)
+    for assay_id in assay_ids:
         # comment this out until you're ready to execute the script
         # assay_API.update_assay(AssayUpsert(id=assay_id, meta={'sequencing_date': date}))
-        print("Validate content with print statements or move this into a notebook")
+        print(f'F ID: {fluidX_id} assay ID: {assay_id}')
 
 # https://pythonbasics.org/read-excel/
 # https://github.com/populationgenomics/metamist/blob/dev/tob_metadata_harmonisation.py

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -92,7 +92,27 @@ def upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date):
     # TODO: confirm asyncio documentation; create async function 
     # await asyncio.gather(api_calls_to_gather)
 
+def compare_tubes_metamist_excel(fluidX_to_assay_ids, fluidX_to_sequencing_date): 
+    # Create a set from the fluidX identifiers only that were extracted from metamist
+    metamist_set_fluidX = set(fluidX_to_assay_ids.keys())
+
+    # Create a second set with fluidX identifiers extracted from excel files
+    excel_set_fluidX = set(fluidX_to_sequencing_date.keys())
+
+    # Find intersection/difference between two sets
+    print(f'Count fluidX in Metamist {len(metamist_set_fluidX)}')
+    print(f'Count fluidX in Excel {len(excel_set_fluidX)}')
+
+    print(f'Diff metamist excel {metamist_set_fluidX.difference(excel_set_fluidX)}')
+    diff_excel_metamist = excel_set_fluidX.difference(metamist_set_fluidX)
+    print(f'Diff excel metamist {diff_excel_metamist}')
+    print(f'Len diff excel metamist {len(diff_excel_metamist)}')
+
+
 if __name__ == '__main__':
     fluidX_to_assay_ids = query_metamist()
     fluidX_to_sequencing_date = extract_excel()
-    upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date)
+    # upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date)
+
+    # Exploration only 
+    compare_tubes_metamist_excel(fluidX_to_assay_ids, fluidX_to_sequencing_date)

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -25,10 +25,10 @@ QUERY_PROJECT_ASSAYS = gql(
 )
 
 
-# TODO: Create separate function for default dict creation
 def query_metamist():
     """
-    Query metamist for bioheart and tob-wgs datasets and map all tube ids to samples.
+    Query metamist for bioheart and tob-wgs datasets and map all tube ids to samples
+    via call to create_default_dict.
     Later calls append_dictionaries(), which collates dicts from the two projects.
 
     :return: Dictionary of lists, mapping tube IDs to samples retrieved from metamist
@@ -50,7 +50,6 @@ def query_metamist():
     # Create default dicts for the two datasets: maps tube IDs to samples
     tob_kccg_id = 'KCCG FluidX tube ID'
     fluidx_to_assay_ids_tob = create_default_dict(tob_samples, tob_kccg_id)
-    print(f'Type for samples is: {type(tob_samples)} OR {type(bioheart_samples)}')
     bioheart_kccg_id = 'fluid_x_tube_id'
     fluidx_to_assay_ids_bioheart = create_default_dict(
         bioheart_samples,
@@ -61,6 +60,13 @@ def query_metamist():
 
 
 def create_default_dict(samples: list, kccg_id: str) -> defaultdict:
+    """
+    Creates defaultdict mapping kccg tube ids to all related samples.
+    Flexible and can be applied to tob-wgs and bioheart.
+
+    :return: defaultdict mapping kccg tubes to sample ids
+    :rtype: defaultdict(list)
+    """
     assays = []
     for sample in samples:
         assays.extend(sample['assays'])
@@ -86,6 +92,9 @@ def append_dictionaries(
 ) -> defaultdict:
     """
     Append two defaultDict objects into a single dictionary.
+    Verifies that there are no intersecting tube ids
+
+    :return: When no intersection of keys
     """
     result = defaultdict(list)
     dicts_to_merge = [fluidx_to_assay_ids_tob, fluidx_to_assay_ids_bioheart]

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -117,6 +117,14 @@ def append_dictionaries(
 
 # TODO: combine pd.apply() into a single expression
 def extract_excel():
+    """
+    Reads in metadata stored in excel spreadsheets. Appends these into
+    a single dataframe and performs required transformations to columns
+    to extract the desired data.
+
+    :return: Fluid tube (key) IDS mapped to sequencing dates (value)
+    :rtype: dict
+    """
     tob_workbook_names = [
         'scripts/metadata_enrichment/1K1K Sequencing Dates.xlsx',
         'scripts/metadata_enrichment/BioHEART Sequencing Dates.xlsx',
@@ -130,9 +138,8 @@ def extract_excel():
         df_list.append(temp_df)
 
     aggregated_df = pd.concat(df_list, ignore_index=True)
-    # Separate accession date and fluidX_id in Sample Identifier column
 
-    # TODO: Can you combine these into a single expression?
+    # Separate accession date and fluidX_id in Sample Identifier column
     aggregated_df['accession_date'] = aggregated_df['Sample Identifier'].apply(
         lambda x: x.split('_')[0],
     )

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -1,4 +1,3 @@
-import csv
 from collections import defaultdict
 
 import pandas as pd
@@ -206,25 +205,15 @@ def compare_tubes_metamist_excel(
     print(f'Diff excel metamist {diff_excel_metamist}')
     print(f'Len diff excel metamist {len(diff_excel_metamist)}')
 
-    # Sort diff_metamist_excel (determine if chronological)
-    print(sorted(filter(None, diff_metamist_excel)))
-
-    # Save diff_metamist_excel to csv
-    with open(
-        './scripts/metadata_enrichment/tubes_missing_in_manifests.csv',
-        'w',
-    ) as file:
-        writer = csv.writer(file, delimiter=',')
-        writer.writerow(['tube_id'])
-        for item in diff_metamist_excel:
-            writer.writerow([item])
+    # Which assays are associated with the 'None' tube?
+    assays_no_tubes = fluidx_to_assay_ids.get(None, 'empty')
+    print(assays_no_tubes)
+    print(len(assays_no_tubes[0]))
 
 
 if __name__ == '__main__':
     fluidx_to_assay_ids = query_metamist()
     if len(fluidx_to_assay_ids) != 0:
         fluidx_to_sequencing_date = extract_excel()
-        # Exploration only
-        # compare_tubes_metamist_excel(fluidx_to_assay_ids, fluidx_to_sequencing_date) # noqa: ERA001
     else:
         print('You have no FluidX_ids/assays to upsert')

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -205,7 +205,6 @@ async def upsert_sequencing_dates(
                 assays_to_update.append(
                     assay_api.update_assay_async(assay_upsert=updated_assay),
                 )
-
     return await asyncio.gather(*assays_to_update)
 
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -22,85 +22,77 @@ QUERY = gql(
     }
     """)
 
-# gives us json output from graphql query 
-# Results are seen in graphql interface as a dictionary
-query_result = query(QUERY)
+def query_metamist():
+    # gives us json output from graphql query 
+    # Results are seen in graphql interface as a dictionary
+    query_result = query(QUERY)
 
-# list of dictionaries of samples per External ID
-tob_samples = query_result['project']['samples']
+    # list of dictionaries of samples per External ID
+    tob_samples = query_result['project']['samples']
 
-# Create list of all assays from tob_samples (at an individual level)
-assays = []
-for sample in tob_samples:
-   assays.extend(sample.get('assays'))
+    # Create list of all assays from tob_samples (at an individual level)
+    assays = []
+    for sample in tob_samples:
+        assays.extend(sample.get('assays'))
 
-# Use default dict to group assays with fluid X tube metadata
-fluidX_to_assay_ids = defaultdict(list)
-for assay in assays:
-   # per assay, extract assay ID and fluid X tubeID
-   # fluid tube id is the key; list contains assay IDs
-   fluidX_tube_id = assay.get('meta').get('KCCG FluidX tube ID')
-   fluidX_to_assay_ids[fluidX_tube_id].append(assay.get('id'))
+    # Use default dict to group assays with fluid X tube metadata
+    fluidX_to_assay_ids = defaultdict(list)
+    for assay in assays:
+        # per assay, extract assay ID and fluid X tubeID
+        # fluid tube id is the key; list contains assay IDs
+        fluidX_tube_id = assay.get('meta').get('KCCG FluidX tube ID')
+        fluidX_to_assay_ids[fluidX_tube_id].append(assay.get('id'))
+    
+    return fluidX_to_assay_ids
 
-tob_workbook_names = ['scripts/metadata_enrichment/1K1K Sequencing Dates.xlsx', 'scripts/metadata_enrichment/BioHEART Sequencing Dates.xlsx']
-# aggregated_df = pd.DataFrame()
-df_list = list()
+def extract_excel():
+    tob_workbook_names = ['scripts/metadata_enrichment/1K1K Sequencing Dates.xlsx', 'scripts/metadata_enrichment/BioHEART Sequencing Dates.xlsx']
+    # aggregated_df = pd.DataFrame()
+    df_list = list()
 
-# Amalgamate data in all sheets listed in tob_sheet_names and bioheart_sheet_names
-for workbook in tob_workbook_names:
-    df_sheet_index = pd.read_excel(workbook, sheet_name=None, header=0)
-    temp_df = pd.concat(df_sheet_index)
-    df_list.append(temp_df)
+    # Amalgamate data in all sheets listed in tob_sheet_names and bioheart_sheet_names
+    for workbook in tob_workbook_names:
+        df_sheet_index = pd.read_excel(workbook, sheet_name=None, header=0)
+        temp_df = pd.concat(df_sheet_index)
+        df_list.append(temp_df)
 
-aggregated_df = pd.concat(df_list, ignore_index=True)
-# Separate accession date and fluidX_id in Sample Identifier column
-aggregated_df['accession_date'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[0])
-aggregated_df['fluidX_id'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[1])
+    aggregated_df = pd.concat(df_list, ignore_index=True)
+    # Separate accession date and fluidX_id in Sample Identifier column
+    aggregated_df['accession_date'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[0])
+    aggregated_df['fluidX_id'] = aggregated_df['Sample Identifier'].apply(lambda x: x.split('_')[1])
 
-# Insert accession value into new dictionary fluidX_to_sequencing_date. Key is FluidX ID
-fluidX_to_sequencing_date = pd.Series(aggregated_df.accession_date.values,index=aggregated_df.fluidX_id).to_dict()
+    # Insert accession value into new dictionary fluidX_to_sequencing_date. Key is FluidX ID
+    fluidX_to_sequencing_date = pd.Series(aggregated_df.accession_date.values,index=aggregated_df.fluidX_id).to_dict()
+    return fluidX_to_sequencing_date
 
-# construct API update calls
-# Iterate through the fluidX_to_assay_IDs dictionary because this is representative of what's already in metamist
-# That is: fluidX_to_assay_IDs groups assays by fluidX_tube_id
+def upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date):
+    # construct API update calls
+    # Iterate through the fluidX_to_assay_IDs dictionary because this is representative of what's already in metamist
+    # That is: fluidX_to_assay_IDs groups assays by fluidX_tube_id
 
-assay_API = AssayApi()
-api_calls_to_gather = []
-assays_without_tubes = []
-tubes_missing_in_manifest = []
+    assay_API = AssayApi()
+    api_calls_to_gather = []
 
+    for fluidX_id, assay_ids in fluidX_to_assay_ids.items(): 
+    # Get sequencing date for each fluidX id from fluidX_to_sequencing_date dict
+        if fluidX_id: 
+            try:
+                date = fluidX_to_sequencing_date[fluidX_id]
+            except KeyError:
+                print(f'Tube ID {fluidX_id} is not in provided sequencing manifest')
+            else:
+                for assay_id in assay_ids:
+                    # Create API call and save to 
+                    api_calls_to_gather.append(assay_API.update_assay_async(AssayUpsert(id=assay_id, meta={'sequencing_date': date})))
+                    # assay_API.update_assay(AssayUpsert(id=assay_id, meta={'sequencing_date': date}))
 
-for fluidX_id, assay_ids in fluidX_to_assay_ids.items(): 
-   # Get sequencing date for each fluidX id from fluidX_to_sequencing_date dict
-    if fluidX_id: 
-        print(f'F ID: {fluidX_id} and assays {assay_ids}')
-        try:
-            date = fluidX_to_sequencing_date[fluidX_id]
-            print(date)
-        except KeyError:
-            print(f'Tube ID {fluidX_id} is not in provided sequencing manifest')
-            tubes_missing_in_manifest.append(assay_ids)
         else:
-            # TODO: depending on how we handle the tube ID with the missing date, this might have to be moved to
-            # a 'finally' clause
-            for assay_id in assay_ids:
-                # comment this out until you're ready to execute the script
-                api_calls_to_gather.append(assay_API.update_assay_async(AssayUpsert(id=assay_id, meta={'sequencing_date': date})))
-                # assay_API.update_assay(AssayUpsert(id=assay_id, meta={'sequencing_date': date}))
-                print(f'F ID: {fluidX_id} assay ID: {assay_id}')
+            print(f'*****\nNO TUBE ID FOR : {fluidX_id} and assays {assay_ids}')
 
-    else:
-        print(f'*****\nNO TUBE ID FOR : {fluidX_id} and assays {assay_ids}')
-        assays_without_tubes.append(assay_ids)
+    # TODO: confirm asyncio documentation; create async function 
+    # await asyncio.gather(api_calls_to_gather)
 
-# TODO: confirm asyncio documentation; create async function 
-# await asyncio.gather(api_calls_to_gather)
-
-print(f'Assays without tubes{assays_without_tubes}')
-print(f'Assays without tubes (cram files) {len(assays_without_tubes[0])}')
-print(f'Tubes missing in manifests {tubes_missing_in_manifest}')
-
-
-# https://pythonbasics.org/read-excel/
-# https://github.com/populationgenomics/metamist/blob/dev/tob_metadata_harmonisation.py
-# update_assayAsync can let us bundle everything together. Develop script in 'snail way' and then adapt for batch/async implementation. 
+if __name__ == '__main__':
+    fluidX_to_assay_ids = query_metamist()
+    fluidX_to_sequencing_date = extract_excel()
+    upsert_sequencing_dates(fluidX_to_assay_ids, fluidX_to_sequencing_date)

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -118,7 +118,6 @@ def append_dictionaries(
     return result
 
 
-# TODO: Update sequencing date with correct value!
 def extract_excel():
     """
     Reads in metadata stored in excel spreadsheets. Appends these into
@@ -163,7 +162,6 @@ def extract_excel():
     ).to_dict()
 
 
-# TODO: combine api calls and
 async def upsert_sequencing_dates(
     fluidx_to_assay_ids: defaultdict,
     fluidx_to_sequencing_date: dict,
@@ -176,7 +174,6 @@ async def upsert_sequencing_dates(
     assays_to_update = []
 
     for fluidx_id, assay_ids in fluidx_to_assay_ids.items():
-        # TODO: Refactor with early return as suggested in PR
         # Get sequencing date for each fluidX id from fluidX_to_sequencing_date dict
         if not fluidx_id:
             print(f'*****\nNO TUBE ID FOR : {fluidx_id} and assays {assay_ids}')


### PR DESCRIPTION
This PR includes a script that enriches existing tob/bioheart records in metamist with sequencing_dates in the meta field. 

See: https://centrepopgen.slack.com/archives/C018KFBCR1C/p1712796597218319

All assays are retrieved from metamist associated with the tob-wgs/bioheart datasets. These are then referenced with tube IDs provided in two separate .csv files. Assays associated with tubes that are referenced in the .csv files are updated with the associated sequencing date in the .csv file.  