### PR TITLE
Update logic in append_dictionaries()

### DIFF
--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -111,7 +111,7 @@ def append_dictionaries(
         # Append bioheart dict to tob dict
         for d in dicts_to_merge:
             for key, value in d.items():
-                result[key].append(value)
+                result[key].extend(value)
     else:
         print(
             f'Error: these keys intersect: {set_tob.intersection(set_bioheart)}',


### PR DESCRIPTION
Bug fix. Updated aggregation of two DefaultDicts in the function append_dictionaries(). 

Using append() added an unnecessary extra layer of lists, which later makes the assay_id unreadable in a nested list. Updating extend avoids this additional layer. 