### PR TITLE
Separate datasets tob bioheart enrichment

### DIFF
--- a/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
+++ b/scripts/metadata_enrichment/tob_bioheart_populate_test_metadata.py
@@ -7,7 +7,7 @@ from metamist.models import AssayUpsert
 QUERY = gql(
     """
         query MyQuery {
-            project(name: "tob-wgs-dev") {
+            project(name: "bioheart-dev") {
                 participants {
                 id
                 samples {
@@ -41,18 +41,19 @@ def upsert_tube_ids(list_participants: defaultdict):
     aapi = AssayApi()
     # Create dictionary containing dummy tube IDs
     dummy_tubes = {
-        1368: 'FDS1000000000',
-        1369: 'FDS1000000001',
-        1370: 'FDS1000000002',
-        1371: 'FDS1000000003',
-        1372: 'FDS1000000004',
+        1430: 'FDS1000000000',
+        1431: 'FDS1000000001',
+        1432: 'FDS1000000002',
+        1433: 'FDS1000000003',
+        1434: 'FDS1000000004',
     }
 
     for key, tube in dummy_tubes.items():
         new_assay = AssayUpsert()
         new_assay['id'] = key
         new_assay['meta'] = {}
-        new_assay['meta']['KCCG FluidX tube ID'] = tube
+        # new_assay['meta']['KCCG FluidX tube ID'] = tube # noqa: ERA001
+        new_assay['meta']['fluid_x_tube_id'] = f'20200101_{tube}'
         aapi.update_assay(assay_upsert=new_assay)
 
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -77,7 +77,6 @@ def create_fluidx_to_assay_ids_dict(samples: list, kccg_id: str) -> defaultdict:
         # per assay, extract assay ID and fluid X tubeID
         # fluid tube id is the key; list contains assay IDs
         fluidx_tube_id = assay['meta'].get(kccg_id)
-
         # Keys for bioheart/tob projects are formatted differently
         if kccg_id.endswith('tube_id'):
             tube_to_assays_defaultdict[fluidx_tube_id.split('_')[1]].append(
@@ -85,6 +84,7 @@ def create_fluidx_to_assay_ids_dict(samples: list, kccg_id: str) -> defaultdict:
             )
         else:
             tube_to_assays_defaultdict[fluidx_tube_id].append(assay['id'])
+
     return tube_to_assays_defaultdict
 
 

--- a/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
+++ b/scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py
@@ -1,7 +1,7 @@
 """
-Script enriches existing assays in Metamist with sequencing dates 
+Script enriches existing assays in Metamist with sequencing dates
 Sequencing dates are extracted from an external .csv file, which maps
-dates to fluidx kccg tube ids. 
+dates to fluidx kccg tube ids.
 """
 
 import asyncio
@@ -52,7 +52,7 @@ def query_metamist(project: str):
     samples = query_result['project']['samples']
 
     # Create default dicts for the project: maps tube IDs to samples
-    kccg_id = 'fluid_x_tube_id' if project == 'bioheart' else 'KCCG FluidX tube ID'  
+    kccg_id = 'fluid_x_tube_id' if project == 'bioheart' else 'KCCG FluidX tube ID'
 
     return create_fluidx_to_assay_ids_dict(samples, kccg_id)
 
@@ -223,12 +223,15 @@ def compare_tubes_metamist_excel(
 @run_as_sync
 async def main(project: str, manifests: tuple, debug: bool):
     """
+    Sample CLI command:
+        python scripts/metadata_enrichment/tob_bioheart_sequencing_dates.py <project/dataset name> \
+        <PATH TO METADATA FILE IN GCP>
+
     :param project str: Target project name. Either bioheart or tob-wgs
     :param workbook_names tuple: Name of files containing enrichment metadata.
     :param debug bool: Boolean flag. True will run script in debug mode, which
         prints out summary data for project.
     """
-    print(project)
     fluidx_to_assay_ids = query_metamist(project)
     if len(fluidx_to_assay_ids) != 0:
         fluidx_to_sequencing_date = extract_excel(manifests)


### PR DESCRIPTION
Following the permissions issue last week where I tried to run script with the `bioheart` dataset on `tob-wgs` data, this PR updates the enrichment script for `tob-wgs`/`bioheart`. The script no longer upserts assays for both datasets simultaneously and will only update a single dataset at a time.

There are also some minor changes to a dummy enrichment script that I created to populate my local test environment. You can largely ignore these changes, or you may recommend that these be deleted from the PR. 