### PR TITLE
Dragmap Parity: No need to split nagim_mt

### DIFF
--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -261,12 +261,8 @@ def main(
     # prepare vds' for comparison
     # As per documentation, hl.methods.concordance() requires the dataset to contain no multiallelic variants.
     # as well as the entry field to be 'GT', also expects MatrixTable, not a VariantDataset
-    if nagim_mt_path:
-        nagim_mt = hl.experimental.sparse_split_multi(
-            nagim_mt,
-            filter_changed_loci=True,
-        )
-    else:
+    # nagim_mt is already split for multiallelic variants
+    if nagim_vds_path:
         nagim_vds = hl.vds.split_multi(nagim_vds, filter_changed_loci=True)
         nagim_mt = nagim_vds.variant_data
 

--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -262,7 +262,10 @@ def main(
     # As per documentation, hl.methods.concordance() requires the dataset to contain no multiallelic variants.
     # as well as the entry field to be 'GT', also expects MatrixTable, not a VariantDataset
     if nagim_mt_path:
-        nagim_mt = hl.split_multi(nagim_mt, filter_changed_loci=True)
+        nagim_mt = hl.experimental.sparse_split_multi(
+            nagim_mt,
+            filter_changed_loci=True,
+        )
     else:
         nagim_vds = hl.vds.split_multi(nagim_vds, filter_changed_loci=True)
         nagim_mt = nagim_vds.variant_data


### PR DESCRIPTION
The nagim matrix table is already split and so do not need to run any splitting of multiallelics prior to concordance