### PR TITLE
Dragmap Parity: Fixing 'None' samples showing up

### DIFF
--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -195,6 +195,15 @@ def rekey_matrix_table(mt: hl.MatrixTable, keyed_ref_table: hl.Table) -> hl.Matr
     # Annotate the MatrixTable with the tobid from keyed_ref_table
     mt = mt.annotate_cols(tobid=keyed_ref_table[mt.s].tobid)
 
+    # Capture the columns where tobid is None
+    none_tobid_samples = mt.filter_cols(hl.is_missing(mt.tobid)).s.collect()
+
+    # Print or log the columns that will be set to None (optional)
+    logging.info(
+        f"""Columns that will be set to None and dropped because of could not find corresponding 'newer' CPGID:" \
+        {none_tobid_samples}""",
+    )
+
     # Filter out columns where tobid is None
     mt = mt.filter_cols(hl.is_defined(mt.tobid))
 

--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -232,8 +232,6 @@ def main(
 
     active_inactive_sg_map = get_active_inactive_sg_map(project, list(samples_to_skip))
 
-    ht_active_key, ht_inactive_key = create_keyed_hail_tables(active_inactive_sg_map)
-
     new_vds = hl.vds.read_vds(new_vds_path)
 
     # read in vds/matrixtables
@@ -258,6 +256,14 @@ def main(
             checked_new_gvcf_paths,
             expids,
         )
+
+    nagim_test_sgids = nagim_mt.s.collect()
+    active_inactive_sg_map2 = {}
+    for i, (tobid, active_inactive_map) in enumerate(active_inactive_sg_map.items()):
+        active_inactive_map['inactive'] = nagim_test_sgids[i]
+        active_inactive_sg_map2[tobid] = active_inactive_map
+
+    ht_active_key, ht_inactive_key = create_keyed_hail_tables(active_inactive_sg_map2)
 
     logging.info(f'nagim path: {nagim_vds_path if nagim_vds_path else nagim_mt_path}')
     logging.info(f'new path: {new_vds_path}')

--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -232,6 +232,8 @@ def main(
 
     active_inactive_sg_map = get_active_inactive_sg_map(project, list(samples_to_skip))
 
+    ht_active_key, ht_inactive_key = create_keyed_hail_tables(active_inactive_sg_map)
+
     new_vds = hl.vds.read_vds(new_vds_path)
 
     # read in vds/matrixtables
@@ -256,14 +258,6 @@ def main(
             checked_new_gvcf_paths,
             expids,
         )
-
-    nagim_test_sgids = nagim_mt.s.collect()
-    active_inactive_sg_map2 = {}
-    for i, (tobid, active_inactive_map) in enumerate(active_inactive_sg_map.items()):
-        active_inactive_map['inactive'] = nagim_test_sgids[i]
-        active_inactive_sg_map2[tobid] = active_inactive_map
-
-    ht_active_key, ht_inactive_key = create_keyed_hail_tables(active_inactive_sg_map2)
 
     logging.info(f'nagim path: {nagim_vds_path if nagim_vds_path else nagim_mt_path}')
     logging.info(f'new path: {new_vds_path}')


### PR DESCRIPTION
Removing samples keyed as None where there are no common samples identified between nagim and new. These non-shared samples are converted to 'None' and when performing `hl.concordance()` these multiple 'None' values are seen as duplicates and messing up the calculation.

Also adding the `hl.split_multi_hts()` function to split the `nagim_mt` to ensure only bi-allelics are being compared