### PR TITLE
Move Dragmap Parity Results To Analysis Bucket

### DIFF
--- a/scripts/validation/copy_dragmap_parity_to_analysis.sh
+++ b/scripts/validation/copy_dragmap_parity_to_analysis.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gsutil -m cp -r gs://cpg-tob-wgs-main/dragmap_parity gs://cpg-tob-wgs-main-analysis/

--- a/scripts/validation/dragmap_parity_check.py
+++ b/scripts/validation/dragmap_parity_check.py
@@ -283,7 +283,7 @@ def main(
     new_mt = new_vds.variant_data
 
     # checkpoint the split MatrixTables
-    output_prefix = f'gs://cpg-{project}/dragmap_parity/{output_version}'
+    output_prefix = f'gs://cpg-{project}-analysis/dragmap_parity/{output_version}'
     logging.info(f'Output prefix {output_prefix}')
 
     # rekey the MatrixTables


### PR DESCRIPTION
The results of dragmap parity anaylsis were mistakenly saved to `-main` instead of `-main-analysis`. 

Moving results to analysis bucket and also changing script so that it saves to analysis bucket